### PR TITLE
Suppress "Uninitialized string offset" errors

### DIFF
--- a/tcpi/tcpdi_parser.php
+++ b/tcpi/tcpdi_parser.php
@@ -812,7 +812,8 @@ class tcpdi_parser {
                 break;
             }
             default: {
-                $frag = $data[$offset] . @$data[$offset+1] . @$data[$offset+2] . @$data[$offset+3];
+                $frag = @$data[$offset] . @$data[$offset+1] . @$data[$offset+2] . @$data[$offset+3];
+
                 switch ($frag) {
                     case 'endo':
                         // indirect object


### PR DESCRIPTION
Use empty string as default values for offset instead of ignoring
errors