### PR TITLE
Non-breaking additions to merge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor/
 tests/output.pdf
 .phpunit.result.cache
 composer.lock
+.idea/

--- a/src/PdfMerge.php
+++ b/src/PdfMerge.php
@@ -67,10 +67,12 @@ class PdfMerge
      *
      * @param string $outputFilename The file to write to
      * @param ?string $destination Destination where to send the document, see TCPDF docs for more info
+     * @param ?bool $autoOrient Set page orientation based on longest dimension, e.g. width > length => 'L'
+     * @param ?bool $keepMargins Keep source margins, otherwise a new 1cm margin is added by default
      * @see \TCPDF::Output()
      * @throws NoFilesDefinedException
      */
-    public function merge(string $outputFilename, ?string $destination = 'F'): string
+    public function merge(string $outputFilename, ?string $destination = 'F', ?bool $autoOrient = false, ?bool $keepMargins = false): string
     {
         if (count($this->files) === 0) {
             throw new NoFilesDefinedException();
@@ -83,8 +85,15 @@ class PdfMerge
                 $pageId = $this->pdf->ImportPage($i);
                 $size = $this->pdf->getTemplateSize($pageId);
 
-                $this->pdf->AddPage('P', $size);
-                $this->pdf->useTemplate($pageId);
+                if ($autoOrient) {
+                    $orientation = $size['w'] > $size['h'] ? 'L' : 'P';
+                } else {
+                    // Maintain legacy behavior
+                    $orientation = 'P';
+                }
+
+                $this->pdf->AddPage($orientation, $size);
+                $this->pdf->useTemplate($pageId, null, null, 0, 0, $keepMargins);
             }
         }
 

--- a/tcpi/tcpdi_parser.php
+++ b/tcpi/tcpdi_parser.php
@@ -908,10 +908,13 @@ class tcpdi_parser {
         do {
             // Get dict element.
             list($key, $eloffset) = $this->getRawObject($dictoffset, $dict);
-            if ($key[0] == '>>') {
+            if (isset($key[0]) && $key[0] == '>>') {
                 break;
             }
             list($element, $dictoffset) = $this->getRawObject($eloffset, $dict);
+            if(!isset($key[1])) {
+                break;
+            }
             $objval['/'.$key[1]] = $element;
             unset($key);
             unset($element);


### PR DESCRIPTION
allows you to auto-detect page orientation as part of merge and also to maintain existing PDF margins during merge.