### PR TITLE
feat: Update TCPDF version requirement to include 7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "8.3.* | 8.4.* | 8.5.*",
-        "tecnickcom/tcpdf": "^6.3"
+        "tecnickcom/tcpdf": "^6.3 | ^7.0"
     },
     "require-dev": {
         "laravel/pint": "^1.5 | ^1.6",


### PR DESCRIPTION
Just a quick check if ci is green.
No. unable to read file: helvetica.json

https://github.com/tecnickcom/TCPDF/blob/main/CHANGELOG.TXT

https://github.com/tecnickcom/TCPDF/issues/867


See https://github.com/karriereat/pdf-merge/issues/43